### PR TITLE
add setting for area splits

### DIFF
--- a/EyeOfTheTemple.asl
+++ b/EyeOfTheTemple.asl
@@ -45,6 +45,8 @@ startup
 {
     vars.Log = (Action<object>)(output => print("[EyeOfTheTemple] " + output));
     vars.Unity = Activator.CreateInstance(Assembly.LoadFrom(@"Components\ULibrary.bin").GetType("ULibrary.Unity"));
+
+    settings.Add("levelSplits", false, "Split when reaching a new area");
 }
 
 init
@@ -88,11 +90,9 @@ split
     if (old.isRunning == 1 && current.isRunning == 2)
         return true;
     
-    // If you also want to split each time you reach a new area in the game, use this:
-    //if (old.latestNewAreaID != current.latestNewAreaID)
-    //    return true;
-
-    return false;
+    // Split each time you reach a new area in the game.
+    if (old.latestNewAreaID != current.latestNewAreaID)
+        return settings["levelSplits"];
 }
 
 gameTime


### PR DESCRIPTION
Users do not (read: should not and usually do not know how to) edit the `.asl` file of a game they're running. Additionally, each time the autosplitter is activated, it will re-download the file from this repo, overwriting any changes they made. Adding a setting is a quick and easy way to allow users to change and actually save their decisions.